### PR TITLE
fnmatch: rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
   - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
   # we use wget to fetch the cmake binaries
   - travis_retry wget --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.6-Linux-x86_64.tar.gz
-  - echo "82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd  cmake-3.14.6-Linux-x86_64.tar.gz"
-  - sha255sum -c cmake_md5.txt
+  - echo "82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd  cmake-3.14.6-Linux-x86_64.tar.gz" > sha256sum.txt
+  - sha256sum -c sha256sum.txt
   - tar -xvf cmake-3.14.6-Linux-x86_64.tar.gz > /dev/null
   - mv cmake-3.14.6-Linux-x86_64 cmake-install
   - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,22 @@ go:
   - '1.11.x'
   - '1.12.x'
 
+compiler:
+  - gcc
+
+install:
+  # first we create a directory for the CMake binaries
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
+  # we use wget to fetch the cmake binaries
+  - travis_retry wget --no-check-certificate https://cmake.org/files/v3.14/cmake-3.14.6-Linux-x86_64.tar.gz
+  - echo "82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd  cmake-3.14.6-Linux-x86_64.tar.gz"
+  - sha255sum -c cmake_md5.txt
+  - tar -xvf cmake-3.14.6-Linux-x86_64.tar.gz > /dev/null
+  - mv cmake-3.14.6-Linux-x86_64 cmake-install
+  - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH
+  - cd ${TRAVIS_BUILD_DIR}
+
 env:
   - GO111MODULE=on
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(editorconfig-core-go)
+cmake_minimum_required(VERSION 3.14)
+enable_testing()
+set(EDITORCONFIG_CMD ${CMAKE_CURRENT_LIST_DIR}/editorconfig)
+add_subdirectory(core-test)

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test-go:
 
 test-core: editorconfig
 	cd core-test; cmake ..
-	cd core-test; ctest -E "^(tab_|indent_size_|lowercase_|comments_after_|octothorpe_|escaped_octothorpe_|max_property_|max_section_name_|root_file_|unset_)" --output-on-failure .
+	cd core-test; ctest -E "^(tab_|indent_size_|comments_after_|octothorpe_|escaped_octothorpe_|max_property_|max_section_name_|root_file_|unset_)" --output-on-failure .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_ROOT_DIR := $(CURDIR)
-SRC := $(shell git ls-files *.go)
+SRC := $(shell git ls-files *.go */*.go)
 
 .PHONY: bin test test-go test-core submodule
 
@@ -15,8 +15,5 @@ test-go:
 	go test -v ./...
 
 test-core: editorconfig
-	cd $(PROJECT_ROOT_DIR)/core-test && \
-		cmake -DEDITORCONFIG_CMD="$(PROJECT_ROOT_DIR)/editorconfig" .
-# Temporarily disable core-test
-	# cd $(PROJECT_ROOT_DIR)/core-test && \
-	# 	ctest --output-on-failure .
+	cd core-test; cmake ..
+	cd core-test; ctest -E "^(tab_|indent_size_|lowercase_|comments_after_|octothorpe_|escaped_octothorpe_|max_property_|max_section_name_|root_file_|unset_)" --output-on-failure .

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test-go:
 
 test-core: editorconfig
 	cd core-test; cmake ..
-	cd core-test; ctest -E "(comments_after_section|octothorpe|unset_|indent_size_default|max_|root_file_mixed_case)" --output-on-failure .
+	cd core-test; ctest -E "(comments_after_section|octothorpe|unset_|_pre_0.9.0|max_|root_file_mixed_case)" --output-on-failure .

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test-go:
 
 test-core: editorconfig
 	cd core-test; cmake ..
-	cd core-test; ctest -E "^(tab_|indent_size_|comments_after_|octothorpe_|escaped_octothorpe_|max_property_|max_section_name_|root_file_|unset_)" --output-on-failure .
+	cd core-test; ctest -E "(comments_after_section|octothorpe|unset_|indent_size_default|max_|root_file_mixed_case)" --output-on-failure .

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ A [Editorconfig][editorconfig] file parser and manipulator for Go.
 > Currently this package does some basic work but does not fully support
 > EditorConfig specs, so using it in "real world" is not recommended.
 
+## Missing features
+
+- `unset`
+- escaping comments in values, probably in [go-ini/ini](https://github.com/go-ini/ini)
+
 ## Installing
 
 We recommend the use of Go 1.11+ modules for this package.
@@ -114,7 +119,7 @@ if err != nil {
 To run the tests:
 
 ```bash
-go test -v
+go test -v ./...
 ```
 
 [editorconfig]: http://editorconfig.org/

--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -70,6 +70,6 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("%s", buffer.String())
+		fmt.Print(buffer.String())
 	}
 }

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -184,9 +184,14 @@ func (d *Definition) InsertToIniFile(iniFile *ini.File) {
 			iniSec.Key(k).SetValue(v)
 		}
 	}
-	if _, ok := d.Raw["indent_size"]; !ok && d.TabWidth > 0 {
-		iniSec.Key("indent_size").SetValue(strconv.Itoa(d.TabWidth))
+	if _, ok := d.Raw["indent_size"]; !ok {
+		if d.TabWidth > 0 {
+			iniSec.Key("indent_size").SetValue(strconv.Itoa(d.TabWidth))
+		} else if d.IndentStyle == IndentStyleTab {
+			iniSec.Key("indent_size").SetValue(IndentStyleTab)
+		}
 	}
+
 	if _, ok := d.Raw["tab_width"]; !ok && len(d.IndentSize) > 0 {
 		if _, err := strconv.Atoi(d.IndentSize); err == nil {
 			iniSec.Key("tab_width").SetValue(d.IndentSize)

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -126,7 +126,6 @@ func (d *Definition) normalize() {
 	// tab_width defaults to indent_size:
 	// https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#tab_width
 	num, err := strconv.Atoi(d.IndentSize)
-
 	if err == nil && d.TabWidth <= 0 {
 		d.TabWidth = num
 	}

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -51,7 +51,11 @@ func TestGetDefinition(t *testing.T) {
 		t.Errorf("Couldn't parse file: %v", err)
 	}
 
-	def := ec.GetDefinitionForFilename("main.go")
+	def, err := ec.GetDefinitionForFilename("main.go")
+	if err != nil {
+		t.Errorf("Couldn't parse file: %v", err)
+	}
+
 	assert.Equal(t, IndentStyleTab, def.IndentStyle)
 	assert.Equal(t, "4", def.IndentSize)
 	assert.Equal(t, 4, def.TabWidth)

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -45,40 +45,6 @@ func TestParse(t *testing.T) {
 	testParse(t, ec)
 }
 
-func TestFilenameMatches(t *testing.T) {
-	assertFilenameMatch := func(pattern, name string) {
-		assert.Equal(t, true, filenameMatches(pattern, name), "\"%s\" should match \"%s\"", name, pattern)
-	}
-	assertFilenameNotMatch := func(pattern, name string) {
-		assert.Equal(t, false, filenameMatches(pattern, name), "\"%s\" should not match \"%s\"", name, pattern)
-	}
-	assertFilenameMatch("*", "main.go")
-	assertFilenameMatch("*.go", "main.go")
-	assertFilenameNotMatch("*.js", "main.go")
-	assertFilenameMatch("main.go", "main.go")
-	assertFilenameMatch("main.go", "foo/bar/main.go")
-	assertFilenameMatch("foo/bar/main.go", "foo/bar/main.go")
-	assertFilenameMatch("foo", "foo/main.go")
-
-	assertFilenameMatch("*.{go,css}", "main.go")
-	assertFilenameNotMatch("*.{js,css}", "main.go")
-	assertFilenameMatch("*.{css,less}", "foo/bar/file.less")
-
-	assertFilenameMatch("{foo}.go", "foo.go")
-	assertFilenameMatch("{foo}.go", "bar/baz/foo.go")
-	assertFilenameMatch("{}.go", "foo.go")
-	assertFilenameMatch("{}.go", "bar.go")
-	assertFilenameNotMatch("a{b,c}.go", "ad.go")
-	assertFilenameMatch("a{b,c}.go", "ab.go")
-	assertFilenameMatch("a{a,b,,d}.go", "ad.go")
-	assertFilenameNotMatch("a{a,b,,d}.go", "ac.go")
-	assertFilenameNotMatch("a{b,c,d}.go", "a.go")
-	assertFilenameMatch("a{b,c,,d}.go", "a.go")
-
-	assertFilenameMatch("a[a-d].go", "ac.go")
-	assertFilenameNotMatch("a[a-d].go", "af.go")
-}
-
 func TestGetDefinition(t *testing.T) {
 	ec, err := ParseFile(testFile)
 	if err != nil {

--- a/fnmatch.go
+++ b/fnmatch.go
@@ -7,11 +7,22 @@ import (
 	"strings"
 )
 
+var (
+	// findLeftBrackets matches the opening left bracket {
+	findLeftBrackets = regexp.MustCompile(`(^|[^\\])\{`)
+	// findLeftBrackets matches the closing right bracket {
+	findRightBrackets = regexp.MustCompile(`(^|[^\\])\}`)
+	// findNumericRange matches a range of number, e.g. -2..5
+	findNumericRange = regexp.MustCompile(`^([+-]?\d+)\.\.([+-]?\d+)$`)
+)
+
+// FnmatchCase tests whether the name matches the given pattern case included.
 func FnmatchCase(pattern, name string) (bool, error) {
 	p, err := translate(pattern)
 	if err != nil {
 		return false, err
 	}
+
 	r, err := regexp.Compile(fmt.Sprintf("^%s$", p))
 	if err != nil {
 		return false, err
@@ -31,11 +42,7 @@ func translate(pattern string) (string, error) {
 	isEscaped := false
 	inBrackets := false
 
-	findLeftBrackets := regexp.MustCompile(`(^|[^\\])\{`)
-	findRightBrackets := regexp.MustCompile(`(^|[^\\])\}`)
 	matchesBraces := len(findLeftBrackets.FindAllString(pattern, -1)) == len(findRightBrackets.FindAllString(pattern, -1))
-
-	findNumericRange := regexp.MustCompile(`^([+-]?\d+)\.\.([+-]?\d+)$`)
 
 	for index < length {
 		r := pat[index]

--- a/fnmatch.go
+++ b/fnmatch.go
@@ -1,0 +1,169 @@
+package editorconfig
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func FnmatchCase(pattern, name string) bool {
+	p, _ := translate(pattern)
+	r, err := regexp.Compile(fmt.Sprintf("^%s$", p))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return r.MatchString(name)
+}
+
+func translate(pattern string) (string, error) {
+	index := 0
+	pat := []rune(pattern)
+	length := len(pat)
+
+	result := strings.Builder{}
+
+	braceLevel := 0
+	isEscaped := false
+	inBrackets := false
+
+	findLeftBrackets := regexp.MustCompile(`(^|[^\\])\{`)
+	findRightBrackets := regexp.MustCompile(`(^|[^\\])\}`)
+	matchesBraces := len(findLeftBrackets.FindAllString(pattern, -1)) == len(findRightBrackets.FindAllString(pattern, -1))
+
+	findNumericRange := regexp.MustCompile(`^([+-]?\d+)\.\.([+-]?\d+)$`)
+
+	for index < length {
+		r := pat[index]
+		index++
+
+		if r == '*' {
+			p := index
+			if p < length && pat[p] == '*' {
+				result.WriteString(".*")
+				index++
+			} else {
+				result.WriteString("[^/]*")
+			}
+		} else if r == '/' {
+			p := index
+			if p+2 < length && pat[p] == '*' && pat[p+1] == '*' && pat[p+2] == '/' {
+				result.WriteString("(?:/|/.*/)")
+				index += 3
+			} else {
+				result.WriteRune(r)
+			}
+		} else if r == '?' {
+			result.WriteString("[^/]")
+		} else if r == '[' {
+			if inBrackets {
+				result.WriteString("\\[")
+			} else {
+				hasSlash := false
+				res := strings.Builder{}
+
+				p := index
+				for p < length {
+					if pat[p] == ']' && pat[p-1] != '\\' {
+						break
+					}
+					res.WriteRune(pat[p])
+					if pat[p] == '/' && pat[p-1] != '\\' {
+						hasSlash = true
+						break
+					}
+					p++
+				}
+				if hasSlash {
+					result.WriteString("\\[" + res.String())
+					index = p + 1
+				} else {
+					inBrackets = true
+					if index < length && pat[index] == '!' || pat[index] == '^' {
+						index++
+						result.WriteString("[^")
+					} else {
+						result.WriteRune('[')
+					}
+				}
+			}
+		} else if r == ']' {
+			if inBrackets && pat[index-2] == '\\' {
+				result.WriteString("\\]")
+			} else {
+				result.WriteRune(r)
+				inBrackets = false
+			}
+		} else if r == '{' {
+			hasComma := false
+			p := index
+			res := strings.Builder{}
+
+			for p < length {
+				if pat[p] == '}' && pat[p-1] != '\\' {
+					break
+				}
+				res.WriteRune(pat[p])
+				if pat[p] == ',' && pat[p-1] != '\\' {
+					hasComma = true
+					break
+				}
+				p++
+			}
+
+			if !hasComma && p < length {
+				inner := res.String()
+				sub := findNumericRange.FindStringSubmatch(inner)
+				if len(sub) == 3 {
+					from, _ := strconv.Atoi(sub[1])
+					to, _ := strconv.Atoi(sub[2])
+					result.WriteString("(?:")
+					// XXX does not scale well
+					for i := from; i < to; i++ {
+						result.WriteString(strconv.Itoa(i))
+						result.WriteRune('|')
+					}
+					result.WriteString(strconv.Itoa(to))
+					result.WriteRune(')')
+				} else {
+					r, _ := translate(inner)
+					result.WriteString(fmt.Sprintf("\\{%s\\}", r))
+				}
+				index = p + 1
+			} else if matchesBraces {
+				result.WriteString("(?:")
+				braceLevel++
+			} else {
+				result.WriteString("\\{")
+			}
+		} else if r == '}' {
+			if braceLevel > 0 {
+				if isEscaped {
+					result.WriteRune('}')
+					isEscaped = false
+				} else {
+					result.WriteRune(')')
+					braceLevel--
+				}
+			} else {
+				result.WriteString("\\}")
+			}
+		} else if r == ',' {
+			if braceLevel == 0 || isEscaped {
+				result.WriteRune(r)
+			} else {
+				result.WriteRune('|')
+			}
+		} else if r != '\\' || isEscaped {
+			result.WriteString(regexp.QuoteMeta(string(r)))
+			isEscaped = false
+		} else {
+			isEscaped = true
+		}
+	}
+
+	return result.String(), nil
+}

--- a/fnmatch.go
+++ b/fnmatch.go
@@ -2,21 +2,22 @@ package editorconfig
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
-func FnmatchCase(pattern, name string) bool {
-	p, _ := translate(pattern)
-	r, err := regexp.Compile(fmt.Sprintf("^%s$", p))
-
+func FnmatchCase(pattern, name string) (bool, error) {
+	p, err := translate(pattern)
 	if err != nil {
-		log.Fatal(err)
+		return false, err
+	}
+	r, err := regexp.Compile(fmt.Sprintf("^%s$", p))
+	if err != nil {
+		return false, err
 	}
 
-	return r.MatchString(name)
+	return r.MatchString(name), nil
 }
 
 func translate(pattern string) (string, error) {

--- a/fnmatch_test.go
+++ b/fnmatch_test.go
@@ -1,0 +1,36 @@
+package editorconfig
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTranslate(t *testing.T) {
+	var tests = [][2]string{
+		{"a*e.c", `a[^/]*e\.c`},
+		{"a**z.c", `a.*z\.c`},
+		{"d/**/z.c", `d(?:/|/.*/)z\.c`},
+		{"som?.c", `som[^/]\.c`},
+		{"[\\]ab].g", `[\]ab]\.g`},
+		{"[ab]].g", `[ab]]\.g`},
+		{"ab[/c", `ab\[/c`},
+		{"*.{py,js,html}", `[^/]*\.(?:py|js|html)`},
+		{"{single}.b", `\{single\}\.b`},
+		{"{{,b,c{d}.i", `\{\{,b,c\{d\}\.i`},
+		{"{a\\,b,cd}", `(?:a,b|cd)`},
+		{"{e,\\},f}", `(?:e|}|f)`},
+	}
+
+	for i, test := range tests {
+		title := fmt.Sprintf("%d) %s => %s", i, test[0], test[1])
+		t.Run(title, func(t *testing.T) {
+			result, err := translate(test[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result != test[1] {
+				t.Errorf("%s != %s", test[1], result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- the fnmatch is somewhat stolen from [editorconfig-core-py](https://github.com/editorconfig/editorconfig-core-py)
- core-test is bumped to v0.13
- 15 tests are still breaking (any help is welcome)

```
92% tests passed, 15 tests failed out of 193

Total Test time (real) =   0.55 sec

The following tests FAILED:
        120 - tab_width_default_ML (Failed)
        122 - indent_size_default_ML (Failed)
        125 - indent_size_default_with_tab_width_ML (Failed)
        126 - lowercase_values1_ML (Failed)
        127 - lowercase_values2_ML (Failed)
        129 - lowercase_names (Failed)
        148 - comments_after_section (Failed)
        155 - octothorpe_comments_after_section (Failed)
        158 - octothorpe_in_property (Failed)
        159 - escaped_octothorpe_in_property (Failed)
        163 - max_property_name (Failed)
        164 - max_property_value (Failed)
        166 - max_section_name_ignore (Failed)
        173 - root_file_mixed_case (Failed)
        186 - unset_indent_size_ML (Failed)
```