### PR TITLE
fnmatch: cache the patterns

### DIFF
--- a/editorconfig.go
+++ b/editorconfig.go
@@ -65,6 +65,7 @@ type Definition struct {
 type Editorconfig struct {
 	Root        bool
 	Definitions []*Definition
+	cache       map[string]*regexp.Regexp
 }
 
 // ParseBytes parses from a slice of bytes.
@@ -76,6 +77,7 @@ func ParseBytes(data []byte) (*Editorconfig, error) {
 
 	editorConfig := &Editorconfig{}
 	editorConfig.Root = iniFile.Section(ini.DEFAULT_SECTION).Key("root").MustBool(false)
+	editorConfig.cache = make(map[string]*regexp.Regexp)
 	for _, sectionStr := range iniFile.SectionStrings() {
 		if sectionStr == ini.DEFAULT_SECTION {
 			continue
@@ -277,7 +279,7 @@ func (e *Editorconfig) GetDefinitionForFilename(name string) (*Definition, error
 		if !strings.HasPrefix(name, "/") {
 			name = "/" + name
 		}
-		ok, err := FnmatchCase(selector, name)
+		ok, err := fnmatchCaseWithCache(selector, name, e.cache)
 		if err != nil {
 			return nil, err
 		}

--- a/fnmatch.go
+++ b/fnmatch.go
@@ -16,6 +16,25 @@ var (
 	findNumericRange = regexp.MustCompile(`^([+-]?\d+)\.\.([+-]?\d+)$`)
 )
 
+func fnmatchCaseWithCache(pattern, name string, cache map[string]*regexp.Regexp) (bool, error) {
+	r, ok := cache[pattern]
+	if !ok {
+		p, err := translate(pattern)
+		if err != nil {
+			return false, err
+		}
+
+		r, err = regexp.Compile(fmt.Sprintf("^%s$", p))
+		if err != nil {
+			return false, err
+		}
+
+		cache[pattern] = r
+	}
+
+	return r.MatchString(name), nil
+}
+
 // FnmatchCase tests whether the name matches the given pattern case included.
 func FnmatchCase(pattern, name string) (bool, error) {
 	p, err := translate(pattern)


### PR DESCRIPTION
translating and compiling the pattern might be over repeatitive and can easily be memoized.