### PR TITLE
allow parsing from io.Reader

### DIFF
--- a/editorconfig.go
+++ b/editorconfig.go
@@ -66,13 +66,32 @@ type Editorconfig struct {
 	Definitions []*Definition
 }
 
-// ParseBytes parses from a slice of bytes.
-func ParseBytes(data []byte) (*Editorconfig, error) {
-	iniFile, err := ini.Load(data)
+// Parse parses from a source handled by go-ini (Reader, filename, byte slice)
+func Parse(source interface{}) (*Editorconfig, error) {
+	iniFile, err := ini.Load(source)
 	if err != nil {
 		return nil, err
 	}
 
+	return NewEditorconfig(iniFile)
+}
+
+// ParseBytes parses from a slice of bytes.
+//
+// Deprecated uses Parse directly.
+func ParseBytes(data []byte) (*Editorconfig, error) {
+	return Parse(data)
+}
+
+// ParseFile parses from a file.
+//
+// Deprecated uses Parse directly.
+func ParseFile(path string) (*Editorconfig, error) {
+	return Parse(path)
+}
+
+// NewEditorconfig builds the configuration from an INI file.
+func NewEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 	editorConfig := &Editorconfig{}
 	editorConfig.Root = iniFile.Section(ini.DEFAULT_SECTION).Key("root").MustBool(false)
 	for _, sectionStr := range iniFile.SectionStrings() {
@@ -102,16 +121,6 @@ func ParseBytes(data []byte) (*Editorconfig, error) {
 		editorConfig.Definitions = append(editorConfig.Definitions, definition)
 	}
 	return editorConfig, nil
-}
-
-// ParseFile parses from a file.
-func ParseFile(f string) (*Editorconfig, error) {
-	data, err := ioutil.ReadFile(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return ParseBytes(data)
 }
 
 // normalize fixes some values to their lowercaes value

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -67,8 +67,8 @@ type Editorconfig struct {
 }
 
 // Parse parses from a source handled by go-ini (Reader, filename, byte slice)
-func Parse(source interface{}) (*Editorconfig, error) {
-	iniFile, err := ini.Load(source)
+func Parse(source interface{}, others ...interface{}) (*Editorconfig, error) {
+	iniFile, err := ini.Load(source, others...)
 	if err != nil {
 		return nil, err
 	}

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -358,7 +358,7 @@ func GetDefinitionForFilenameWithConfigname(filename string, configname string) 
 		if _, err := os.Stat(ecFile); os.IsNotExist(err) {
 			continue
 		}
-		ec, err := ParseFile(ecFile)
+		ec, err := Parse(ecFile)
 		if err != nil {
 			return nil, err
 		}

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -1,6 +1,7 @@
 package editorconfig
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,8 +37,37 @@ func testParse(t *testing.T, ec *Editorconfig) {
 	assert.Equal(t, 2, def.TabWidth)
 }
 
-func TestParse(t *testing.T) {
+func TestParseFile(t *testing.T) {
 	ec, err := ParseFile(testFile)
+	if err != nil {
+		t.Errorf("Couldn't parse file: %v", err)
+	}
+
+	testParse(t, ec)
+}
+
+func TestParseBytes(t *testing.T) {
+	data, err := ioutil.ReadFile(testFile)
+	if err != nil {
+		t.Errorf("Couldn't read file: %v", err)
+	}
+
+	ec, err := ParseBytes(data)
+	if err != nil {
+		t.Errorf("Couldn't parse data: %v", err)
+	}
+
+	testParse(t, ec)
+}
+
+func TestParseReader(t *testing.T) {
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Errorf("Couldn't open file: %v", err)
+	}
+	defer f.Close()
+
+	ec, err := Parse(f)
 	if err != nil {
 		t.Errorf("Couldn't parse file: %v", err)
 	}


### PR DESCRIPTION
Hi @mvdan, here is my takes on #32 (#31)

`ini.Load` is powerful enough to let it handle the various cases, https://gowalker.org/gopkg.in/ini.v1#Load