### PR TITLE
config: skip lengthy values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test-go:
 
 test-core: editorconfig
 	cd core-test; cmake ..
-	cd core-test; ctest -E "^(comments_after_section|(escaped_)?octothorpe_(in_|comments_).*|indent_size_default_pre_0.9.0|max_property_.*|max_section_name_ignore|root_file_mixed_case)$$" .
+	cd core-test; ctest -E "^(comments_after_section|(escaped_)?octothorpe_(in_|comments_).*|indent_size_default_pre_0.9.0|root_file_mixed_case)$$" .

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -42,6 +42,13 @@ const (
 	CharsetUTF8BOM = "utf-8 bom"
 )
 
+// Limits for section name, properties, and values.
+const (
+	MaxPropertyLength = 50
+	MaxSectionLength  = 4096
+	MaxValueLength    = 255
+)
+
 // Definition represents a definition inside the .editorconfig file.
 // E.g. a section of the file.
 // The definition is composed of the selector ("*", "*.go", "*.{js.css}", etc),
@@ -109,6 +116,9 @@ func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 		if sectionStr == ini.DEFAULT_SECTION {
 			continue
 		}
+		if len(sectionStr) > MaxSectionLength {
+			continue
+		}
 		var (
 			iniSection = iniFile.Section(sectionStr)
 			definition = &Definition{}
@@ -121,6 +131,9 @@ func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 
 		// Shallow copy all properties
 		for k, v := range iniSection.KeysHash() {
+			if len(k) > MaxPropertyLength || len(v) > MaxValueLength {
+				continue
+			}
 			raw[strings.ToLower(k)] = v
 		}
 


### PR DESCRIPTION
Passing three more tests regarding maximum length for section name, properties and values.

> The maximum length of a section name is 4096 characters. All sections exceeding this limit are ignored.
> [...]
> The maximum length of a property name is 50 characters and the maximum length of a property value is 255 characters. Any property beyond these limits would be ignored.
>
> https://editorconfig-specification.readthedocs.io/en/latest/