### PR TITLE
tests for io.reader

### DIFF
--- a/editorconfig.go
+++ b/editorconfig.go
@@ -67,20 +67,42 @@ type Editorconfig struct {
 	Definitions []*Definition
 }
 
-// ParseBytes parses from a slice of bytes.
-//
-// Deprecated: use Parse instead.
-func ParseBytes(data []byte) (*Editorconfig, error) {
-	return Parse(bytes.NewReader(data))
-}
-
 // Parse parses from a reader.
 func Parse(r io.Reader) (*Editorconfig, error) {
-	iniFile, err := ini.Load(ioutil.NopCloser(r))
+	iniFile, err := ini.Load(r)
 	if err != nil {
 		return nil, err
 	}
 
+	return newEditorconfig(iniFile)
+}
+
+// ParseBytes parses from a slice of bytes.
+//
+// Deprecated: use Parse instead.
+func ParseBytes(data []byte) (*Editorconfig, error) {
+	iniFile, err := ini.Load(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEditorconfig(iniFile)
+}
+
+// ParseFile parses from a file.
+//
+// Deprecated: use Parse instead.
+func ParseFile(path string) (*Editorconfig, error) {
+	iniFile, err := ini.Load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEditorconfig(iniFile)
+}
+
+// newEditorconfig builds the configuration from an INI file.
+func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 	editorConfig := &Editorconfig{}
 	editorConfig.Root = iniFile.Section(ini.DEFAULT_SECTION).Key("root").MustBool(false)
 	for _, sectionStr := range iniFile.SectionStrings() {
@@ -110,16 +132,6 @@ func Parse(r io.Reader) (*Editorconfig, error) {
 		editorConfig.Definitions = append(editorConfig.Definitions, definition)
 	}
 	return editorConfig, nil
-}
-
-// ParseFile parses from a file.
-func ParseFile(path string) (*Editorconfig, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	return Parse(f)
 }
 
 // normalize fixes some values to their lowercaes value

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -1,6 +1,7 @@
 package editorconfig
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,8 +37,37 @@ func testParse(t *testing.T, ec *Editorconfig) {
 	assert.Equal(t, 2, def.TabWidth)
 }
 
-func TestParse(t *testing.T) {
+func TestParseFile(t *testing.T) {
 	ec, err := ParseFile(testFile)
+	if err != nil {
+		t.Errorf("Couldn't parse file: %v", err)
+	}
+
+	testParse(t, ec)
+}
+
+func TestParseBytes(t *testing.T) {
+	data, err := ioutil.ReadFile(testFile)
+	if err != nil {
+		t.Errorf("Couldn't read file: %v", err)
+	}
+
+	ec, err := ParseBytes(data)
+	if err != nil {
+		t.Errorf("Couldn't parse data: %v", err)
+	}
+
+	testParse(t, ec)
+}
+
+func TestParseReader(t *testing.T) {
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Errorf("Couldn't open file: %v", err)
+	}
+	defer f.Close()
+
+	ec, err := Parse(f)
 	if err != nil {
 		t.Errorf("Couldn't parse file: %v", err)
 	}


### PR DESCRIPTION
a redo of #32, which had tests and remove some things I consider to be hacks, such as `ioutil.NopCloser(io.Reader)`.