### PR TITLE
ec: implement Write(io.Writer)

### DIFF
--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -55,7 +54,6 @@ func main() {
 
 		var (
 			iniFile = ini.Empty()
-			buffer  = bytes.NewBuffer(nil)
 		)
 		ini.PrettyFormat = false
 		if len(rest) < 2 {
@@ -64,10 +62,9 @@ func main() {
 			def.Selector = absolutePath
 		}
 		def.InsertToIniFile(iniFile)
-		_, err = iniFile.WriteTo(buffer)
+		_, err = iniFile.WriteTo(os.Stdout)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Print(buffer.String())
 	}
 }

--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -45,14 +45,12 @@ func main() {
 	for _, file := range rest {
 		absolutePath, err := filepath.Abs(file)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 
 		def, err := editorconfig.GetDefinitionForFilenameWithConfigname(absolutePath, configName)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 
 		var (

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -325,18 +325,8 @@ func boolToString(b bool) string {
 // Serialize converts the Editorconfig to a slice of bytes, containing the
 // content of the file in the INI format.
 func (e *Editorconfig) Serialize() ([]byte, error) {
-	var (
-		iniFile = ini.Empty()
-		buffer  = bytes.NewBuffer(nil)
-	)
-	iniFile.Section(ini.DEFAULT_SECTION).Comment = "http://editorconfig.org"
-	if e.Root {
-		iniFile.Section(ini.DEFAULT_SECTION).Key("root").SetValue(boolToString(e.Root))
-	}
-	for _, d := range e.Definitions {
-		d.InsertToIniFile(iniFile)
-	}
-	_, err := iniFile.WriteTo(buffer)
+	buffer := bytes.NewBuffer(nil)
+	err := e.Write(buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -345,11 +335,17 @@ func (e *Editorconfig) Serialize() ([]byte, error) {
 
 // Write writes the Editorconfig to the Writer in a compatible INI file.
 func (e *Editorconfig) Write(w io.Writer) error {
-	data, err := e.Serialize()
-	if err != nil {
-		return err
+	var (
+		iniFile = ini.Empty()
+	)
+	iniFile.Section(ini.DEFAULT_SECTION).Comment = "http://editorconfig.org"
+	if e.Root {
+		iniFile.Section(ini.DEFAULT_SECTION).Key("root").SetValue(boolToString(e.Root))
 	}
-	_, err = w.Write(data)
+	for _, d := range e.Definitions {
+		d.InsertToIniFile(iniFile)
+	}
+	_, err := iniFile.WriteTo(w)
 	return err
 }
 

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -344,13 +343,23 @@ func (e *Editorconfig) Serialize() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// Save saves the Editorconfig to a compatible INI file.
-func (e *Editorconfig) Save(filename string) error {
+// Write writes the Editorconfig to the Writer in a compatible INI file.
+func (e *Editorconfig) Write(w io.Writer) error {
 	data, err := e.Serialize()
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, data, 0666)
+	_, err = w.Write(data)
+	return err
+}
+
+// Save saves the Editorconfig to a compatible INI file.
+func (e *Editorconfig) Save(filename string) error {
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	return e.Write(f)
 }
 
 // GetDefinitionForFilename given a filename, searches

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -92,22 +92,21 @@ func TestWrite(t *testing.T) {
 	}
 
 	tempFile := filepath.Join(os.TempDir(), ".editorconfig")
-	defer os.Remove(tempFile)
 
 	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	assert.Nil(t, err)
-	defer os.Remove(tempFile)
+	defer func() {
+		f.Close()
+		os.Remove(tempFile)
+	}()
 
 	err = ec.Write(f)
 	assert.Nil(t, err)
-
-	f.Close()
 
 	savedEc, err := ParseFile(tempFile)
 	assert.Nil(t, err)
 
 	testParse(t, savedEc)
-	os.Remove(tempFile)
 }
 
 func TestSave(t *testing.T) {

--- a/editorconfig_test.go
+++ b/editorconfig_test.go
@@ -39,38 +39,28 @@ func testParse(t *testing.T, ec *Editorconfig) {
 
 func TestParseFile(t *testing.T) {
 	ec, err := ParseFile(testFile)
-	if err != nil {
-		t.Errorf("Couldn't parse file: %v", err)
-	}
+	assert.Nil(t, err)
 
 	testParse(t, ec)
 }
 
 func TestParseBytes(t *testing.T) {
 	data, err := ioutil.ReadFile(testFile)
-	if err != nil {
-		t.Errorf("Couldn't read file: %v", err)
-	}
+	assert.Nil(t, err)
 
 	ec, err := ParseBytes(data)
-	if err != nil {
-		t.Errorf("Couldn't parse data: %v", err)
-	}
+	assert.Nil(t, err)
 
 	testParse(t, ec)
 }
 
 func TestParseReader(t *testing.T) {
 	f, err := os.Open(testFile)
-	if err != nil {
-		t.Errorf("Couldn't open file: %v", err)
-	}
+	assert.Nil(t, err)
 	defer f.Close()
 
 	ec, err := Parse(f)
-	if err != nil {
-		t.Errorf("Couldn't parse file: %v", err)
-	}
+	assert.Nil(t, err)
 
 	testParse(t, ec)
 }
@@ -93,6 +83,31 @@ func TestGetDefinition(t *testing.T) {
 	assert.Equal(t, CharsetUTF8, def.Charset)
 	assert.Equal(t, (*bool)(nil), def.InsertFinalNewline)
 	assert.Equal(t, EndOfLineLf, def.EndOfLine)
+}
+
+func TestWrite(t *testing.T) {
+	ec, err := ParseFile(testFile)
+	if err != nil {
+		t.Errorf("Couldn't parse file: %v", err)
+	}
+
+	tempFile := filepath.Join(os.TempDir(), ".editorconfig")
+	defer os.Remove(tempFile)
+
+	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	assert.Nil(t, err)
+	defer os.Remove(tempFile)
+
+	err = ec.Write(f)
+	assert.Nil(t, err)
+
+	f.Close()
+
+	savedEc, err := ParseFile(tempFile)
+	assert.Nil(t, err)
+
+	testParse(t, savedEc)
+	os.Remove(tempFile)
 }
 
 func TestSave(t *testing.T) {


### PR DESCRIPTION
A follow up to #31, there is a `Write` accepting the `io.Writer` interface.