### PR TITLE
changelog: prepare v2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log
 
+## v2.1.2 - 2019-10-12
+
+- Allow parsing from an `io.Reader`, effectively deprecating `ParseBytes`
+  by [@mvdan](https://github.com/mvdan)
+  ([#32](https://github.com/editorconfig/editorconfig-core-go/pull/32));
+- Add support for the special `unset` value by [@greut](https://github.com/greut)
+  ([#19](https://github.com/editorconfig/editorconfig-core-go/pull/19));
+- Skip values, properties or section that are considered too long
+  ([#35](https://github.com/editorconfig/editorconfig-core-go/pull/35));
+- Clean up and documentation work by [@mstruebing](https://github.com/mstruebing/)
+  ([#23](https://github.com/editorconfig/editorconfig-core-go/pull/23),
+  [#24](https://github.com/editorconfig/editorconfig-core-go/pull/24)).
+
 ## v2.1.1 - 2019-08-18
 
 - Fix a small path bug
@@ -15,6 +28,6 @@
 ## v2.0.0 - 2019-07-14
 
 - This project now uses [Go Modules](https://blog.golang.org/using-go-modules)
-  ([#14](https://github.com/editorconfig/editorconfig-core-go/pull/14)).
+  ([#14](https://github.com/editorconfig/editorconfig-core-go/pull/14));
 - The import path has been changed from `gopkg.in/editorconfig/editorconfig-core-go.v1`
   to `github.com/editorconfig/editorconfig-core-go/v2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## v2.1.2 - 2019-10-12
+## v2.2.0 - 2019-10-12
 
 - Allow parsing from an `io.Reader`, effectively deprecating `ParseBytes`
   by [@mvdan](https://github.com/mvdan)

--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// Version indicates the current version number
-	Version = "2.1.1"
+	Version = "2.1.2"
 )
 
 func main() {

--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// Version indicates the current version number
-	Version = "2.1.2"
+	Version = "2.2.0"
 )
 
 func main() {


### PR DESCRIPTION
Let's publish some code. Bumping the minor version as there is the new `Parse` call.