### PR TITLE
readme: use Parse rather than ParseFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ import (
 ### Parse from file
 
 ```go
-editorConfig, err := editorconfig.ParseFile("path/to/.editorconfig")
+fp, err := os.Open("path/to/.editorconfig")
+if err != nil {
+  log.Fatal(err)
+}
+defer fp.Close()
+
+editorConfig, err := editorconfig.Parse(fp)
 if err != nil {
     log.Fatal(err)
 }

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -379,10 +379,12 @@ func GetDefinitionForFilenameWithConfigname(filename string, configname string) 
 	for dir != filepath.Dir(dir) {
 		dir = filepath.Dir(dir)
 		ecFile := filepath.Join(dir, configname)
-		if _, err := os.Stat(ecFile); os.IsNotExist(err) {
+		fp, err := os.Open(ecFile)
+		if os.IsNotExist(err) {
 			continue
 		}
-		ec, err := ParseFile(ecFile)
+		defer fp.Close()
+		ec, err := Parse(fp)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
as `ParseFile` is deprecated, let's avoid a `stat` call and go with `Parse`.