### PR TITLE
editorconfig: fix error mangling

### DIFF
--- a/editorconfig.go
+++ b/editorconfig.go
@@ -98,7 +98,10 @@ func newDefinition(config Config) (*Definition, error) {
 		dir = filepath.Dir(dir)
 		ecFile := filepath.Join(dir, config.Name)
 		fp, err := os.Open(ecFile)
-		if os.IsNotExist(err) {
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
 			continue
 		}
 		defer fp.Close()


### PR DESCRIPTION
If the .editorconfig file cannot be read for a different reason than
the file does not exist, the error is not dealt with and a panic will
occur.