### PR TITLE
cached loader and some refactoring

### DIFF
--- a/cached_parser.go
+++ b/cached_parser.go
@@ -1,0 +1,60 @@
+package editorconfig
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/ini.v1"
+)
+
+type CachedParser struct {
+	iniFiles map[string]*ini.File
+	regexps  map[string]*regexp.Regexp
+}
+
+func NewCachedParser() *CachedParser {
+	return &CachedParser{
+		iniFiles: make(map[string]*ini.File),
+		regexps:  make(map[string]*regexp.Regexp),
+	}
+}
+
+func (parser *CachedParser) ParseIni(filename string) (*ini.File, error) {
+	iniFile, ok := parser.iniFiles[filename]
+	if !ok {
+		fp, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		defer fp.Close()
+
+		iniFile, err = ini.Load(fp)
+		if err != nil {
+			return nil, err
+		}
+
+		parser.iniFiles[filename] = iniFile
+	}
+
+	return iniFile, nil
+}
+
+// FnmatchCase calls the module's FnmatchCase.
+func (parser *CachedParser) FnmatchCase(selector string, filename string) (bool, error) {
+	r, ok := parser.regexps[selector]
+	if !ok {
+		p := translate(selector)
+
+		var err error
+		r, err = regexp.Compile(fmt.Sprintf("^%s$", p))
+		if err != nil {
+			return false, err
+		}
+
+		parser.regexps[selector] = r
+	}
+
+	return r.MatchString(filename), nil
+}

--- a/cmd/editorconfig/main.go
+++ b/cmd/editorconfig/main.go
@@ -40,12 +40,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	config := &editorconfig.Config{
+		Name:    configName,
+		Version: configVersion,
+	}
+
+	if len(rest) > 1 {
+		config.Parser = editorconfig.NewCachedParser()
+	}
+
 	for _, file := range rest {
-		def, err := editorconfig.NewDefinition(editorconfig.Config{
-			Path:    file,
-			Name:    configName,
-			Version: configVersion,
-		})
+		def, err := config.Load(file)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,91 @@
+package editorconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/blang/semver"
+)
+
+var (
+	v0_9_0 = semver.Version{
+		Major: 0,
+		Minor: 9,
+		Patch: 0,
+	}
+)
+
+// Config holds the configuration
+type Config struct {
+	Path    string
+	Name    string
+	Version string
+	Parser  Parser
+}
+
+func (config *Config) Load(filename string) (*Definition, error) {
+	// idiomatic go allows empty struct
+	if config.Parser == nil {
+		config.Parser = new(SimpleParser)
+	}
+
+	filename, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ecFile := config.Name
+	if ecFile == "" {
+		ecFile = ConfigNameDefault
+	}
+
+	definition := &Definition{}
+	definition.Raw = make(map[string]string)
+
+	if config.Version != "" {
+		version, err := semver.New(config.Version)
+		if err != nil {
+			return nil, err
+		}
+		definition.version = version
+	}
+
+	dir := filename
+	for dir != filepath.Dir(dir) {
+		dir = filepath.Dir(dir)
+
+		ini, err := config.Parser.ParseIni(filepath.Join(dir, ecFile))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		ec, err := newEditorconfig(ini)
+		if err != nil {
+			return nil, err
+		}
+
+		// give it the current config.
+		ec.config = config
+
+		relativeFilename := filename
+		if len(dir) < len(relativeFilename) {
+			relativeFilename = relativeFilename[len(dir):]
+		}
+
+		def, err := ec.GetDefinitionForFilename(relativeFilename)
+		if err != nil {
+			return nil, err
+		}
+
+		definition.merge(def)
+
+		if ec.Root {
+			break
+		}
+	}
+
+	return definition, nil
+}

--- a/definition.go
+++ b/definition.go
@@ -1,0 +1,177 @@
+package editorconfig
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/blang/semver"
+	"gopkg.in/ini.v1"
+)
+
+// Definition represents a definition inside the .editorconfig file.
+// E.g. a section of the file.
+// The definition is composed of the selector ("*", "*.go", "*.{js.css}", etc),
+// plus the properties of the selected files.
+type Definition struct {
+	Selector string `ini:"-" json:"-"`
+
+	Charset                string            `ini:"charset" json:"charset,omitempty"`
+	IndentStyle            string            `ini:"indent_style" json:"indent_style,omitempty"`
+	IndentSize             string            `ini:"indent_size" json:"indent_size,omitempty"`
+	TabWidth               int               `ini:"-" json:"-"`
+	EndOfLine              string            `ini:"end_of_line" json:"end_of_line,omitempty"`
+	TrimTrailingWhitespace *bool             `ini:"-" json:"-"`
+	InsertFinalNewline     *bool             `ini:"-" json:"-"`
+	Raw                    map[string]string `ini:"-" json:"-"`
+	version                *semver.Version
+}
+
+// NewDefinition builds a definition from a given config
+func NewDefinition(config Config) (*Definition, error) {
+	return config.Load(config.Path)
+}
+
+// normalize fixes some values to their lowercaes value
+func (d *Definition) normalize() error {
+	d.Charset = strings.ToLower(d.Charset)
+	d.EndOfLine = strings.ToLower(d.Raw["end_of_line"])
+	d.IndentStyle = strings.ToLower(d.Raw["indent_style"])
+
+	trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
+	if ok && trimTrailingWhitespace != "unset" {
+		trim, err := strconv.ParseBool(trimTrailingWhitespace)
+		if err != nil {
+			return fmt.Errorf("trim_trailing_whitespace=%s is not an acceptable value. %s", trimTrailingWhitespace, err)
+		}
+		d.TrimTrailingWhitespace = &trim
+	}
+
+	insertFinalNewline, ok := d.Raw["insert_final_newline"]
+	if ok && insertFinalNewline != "unset" {
+		insert, err := strconv.ParseBool(insertFinalNewline)
+		if err != nil {
+			return fmt.Errorf("insert_final_newline=%s is not an acceptable value. %s", insertFinalNewline, err)
+		}
+		d.InsertFinalNewline = &insert
+	}
+
+	// tab_width from Raw
+	tabWidth, ok := d.Raw["tab_width"]
+	if ok && tabWidth != "unset" {
+		num, err := strconv.Atoi(tabWidth)
+		if err != nil {
+			return fmt.Errorf("tab_width=%s is not an acceptable value. %s", tabWidth, err)
+		}
+		d.TabWidth = num
+	}
+
+	// tab_width defaults to indent_size:
+	// https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#tab_width
+	num, err := strconv.Atoi(d.IndentSize)
+	if err == nil && d.TabWidth <= 0 {
+		d.TabWidth = num
+	}
+
+	return nil
+}
+
+// merge the parent definition into the child definition
+func (d *Definition) merge(md *Definition) {
+	if len(d.Charset) == 0 {
+		d.Charset = md.Charset
+	}
+	if len(d.IndentStyle) == 0 {
+		d.IndentStyle = md.IndentStyle
+	}
+	if len(d.IndentSize) == 0 {
+		d.IndentSize = md.IndentSize
+	}
+	if d.TabWidth <= 0 {
+		d.TabWidth = md.TabWidth
+	}
+	if len(d.EndOfLine) == 0 {
+		d.EndOfLine = md.EndOfLine
+	}
+	if trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]; !ok || trimTrailingWhitespace != "unset" {
+		if d.TrimTrailingWhitespace == nil {
+			d.TrimTrailingWhitespace = md.TrimTrailingWhitespace
+		}
+	}
+	if insertFinalNewline, ok := d.Raw["insert_final_newline"]; !ok || insertFinalNewline != "unset" {
+		if d.InsertFinalNewline == nil {
+			d.InsertFinalNewline = md.InsertFinalNewline
+		}
+	}
+
+	for k, v := range md.Raw {
+		if _, ok := d.Raw[k]; !ok {
+			d.Raw[k] = v
+		}
+	}
+}
+
+// InsertToIniFile ... TODO
+func (d *Definition) InsertToIniFile(iniFile *ini.File) {
+	iniSec := iniFile.Section(d.Selector)
+	for k, v := range d.Raw {
+		if k == "insert_final_newline" {
+			if d.InsertFinalNewline != nil {
+				iniSec.NewKey(k, strconv.FormatBool(*d.InsertFinalNewline))
+			} else {
+				insertFinalNewline, ok := d.Raw["insert_final_newline"]
+				if ok {
+					iniSec.NewKey(k, strings.ToLower(insertFinalNewline))
+				}
+			}
+		} else if k == "trim_trailing_whitespace" {
+			if d.TrimTrailingWhitespace != nil {
+				iniSec.NewKey(k, strconv.FormatBool(*d.TrimTrailingWhitespace))
+			} else {
+				trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
+				if ok {
+					iniSec.NewKey(k, strings.ToLower(trimTrailingWhitespace))
+				}
+			}
+		} else if k == "charset" {
+			iniSec.NewKey(k, d.Charset)
+		} else if k == "end_of_line" {
+			iniSec.NewKey(k, d.EndOfLine)
+		} else if k == "indent_style" {
+			iniSec.NewKey(k, d.IndentStyle)
+		} else if k == "tab_width" {
+			tabWidth, ok := d.Raw["tab_width"]
+			if ok && tabWidth == "unset" {
+				iniSec.NewKey(k, tabWidth)
+			} else {
+				iniSec.NewKey(k, strconv.Itoa(d.TabWidth))
+			}
+		} else if k == "indent_size" {
+			iniSec.NewKey(k, d.IndentSize)
+		} else {
+			iniSec.NewKey(k, v)
+		}
+	}
+
+	if _, ok := d.Raw["indent_size"]; !ok {
+		tabWidth, ok := d.Raw["tab_width"]
+		if ok && tabWidth == "unset" {
+			// do nothing
+		} else if d.TabWidth > 0 {
+			iniSec.NewKey("indent_size", strconv.Itoa(d.TabWidth))
+		} else if d.IndentStyle == IndentStyleTab && (d.version == nil || d.version.GTE(v0_9_0)) {
+			iniSec.NewKey("indent_size", IndentStyleTab)
+		}
+	}
+
+	if _, ok := d.Raw["tab_width"]; !ok {
+		if d.IndentSize == "unset" {
+			iniSec.NewKey("tab_width", d.IndentSize)
+		} else {
+			_, err := strconv.Atoi(d.IndentSize)
+			if err == nil {
+				iniSec.NewKey("tab_width", d.Raw["indent_size"])
+			}
+		}
+	}
+}

--- a/definition.go
+++ b/definition.go
@@ -39,7 +39,7 @@ func (d *Definition) normalize() error {
 	d.IndentStyle = strings.ToLower(d.Raw["indent_style"])
 
 	trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
-	if ok && trimTrailingWhitespace != "unset" {
+	if ok && trimTrailingWhitespace != UnsetValue {
 		trim, err := strconv.ParseBool(trimTrailingWhitespace)
 		if err != nil {
 			return fmt.Errorf("trim_trailing_whitespace=%s is not an acceptable value. %s", trimTrailingWhitespace, err)
@@ -48,7 +48,7 @@ func (d *Definition) normalize() error {
 	}
 
 	insertFinalNewline, ok := d.Raw["insert_final_newline"]
-	if ok && insertFinalNewline != "unset" {
+	if ok && insertFinalNewline != UnsetValue {
 		insert, err := strconv.ParseBool(insertFinalNewline)
 		if err != nil {
 			return fmt.Errorf("insert_final_newline=%s is not an acceptable value. %s", insertFinalNewline, err)
@@ -58,7 +58,7 @@ func (d *Definition) normalize() error {
 
 	// tab_width from Raw
 	tabWidth, ok := d.Raw["tab_width"]
-	if ok && tabWidth != "unset" {
+	if ok && tabWidth != UnsetValue {
 		num, err := strconv.Atoi(tabWidth)
 		if err != nil {
 			return fmt.Errorf("tab_width=%s is not an acceptable value. %s", tabWidth, err)
@@ -93,12 +93,12 @@ func (d *Definition) merge(md *Definition) {
 	if len(d.EndOfLine) == 0 {
 		d.EndOfLine = md.EndOfLine
 	}
-	if trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]; !ok || trimTrailingWhitespace != "unset" {
+	if trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]; !ok || trimTrailingWhitespace != UnsetValue {
 		if d.TrimTrailingWhitespace == nil {
 			d.TrimTrailingWhitespace = md.TrimTrailingWhitespace
 		}
 	}
-	if insertFinalNewline, ok := d.Raw["insert_final_newline"]; !ok || insertFinalNewline != "unset" {
+	if insertFinalNewline, ok := d.Raw["insert_final_newline"]; !ok || insertFinalNewline != UnsetValue {
 		if d.InsertFinalNewline == nil {
 			d.InsertFinalNewline = md.InsertFinalNewline
 		}
@@ -115,62 +115,66 @@ func (d *Definition) merge(md *Definition) {
 func (d *Definition) InsertToIniFile(iniFile *ini.File) {
 	iniSec := iniFile.Section(d.Selector)
 	for k, v := range d.Raw {
-		if k == "insert_final_newline" {
+		switch k {
+		case "insert_final_newline":
 			if d.InsertFinalNewline != nil {
-				iniSec.NewKey(k, strconv.FormatBool(*d.InsertFinalNewline))
+				v = strconv.FormatBool(*d.InsertFinalNewline)
 			} else {
 				insertFinalNewline, ok := d.Raw["insert_final_newline"]
-				if ok {
-					iniSec.NewKey(k, strings.ToLower(insertFinalNewline))
+				if !ok {
+					break
 				}
+				v = strings.ToLower(insertFinalNewline)
 			}
-		} else if k == "trim_trailing_whitespace" {
+		case "trim_trailing_whitespace":
 			if d.TrimTrailingWhitespace != nil {
-				iniSec.NewKey(k, strconv.FormatBool(*d.TrimTrailingWhitespace))
+				v = strconv.FormatBool(*d.TrimTrailingWhitespace)
 			} else {
 				trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
-				if ok {
-					iniSec.NewKey(k, strings.ToLower(trimTrailingWhitespace))
+				if !ok {
+					break
 				}
+				v = strings.ToLower(trimTrailingWhitespace)
 			}
-		} else if k == "charset" {
-			iniSec.NewKey(k, d.Charset)
-		} else if k == "end_of_line" {
-			iniSec.NewKey(k, d.EndOfLine)
-		} else if k == "indent_style" {
-			iniSec.NewKey(k, d.IndentStyle)
-		} else if k == "tab_width" {
+		case "charset":
+			v = d.Charset
+		case "end_of_line":
+			v = d.EndOfLine
+		case "indent_style":
+			v = d.IndentStyle
+		case "tab_width":
 			tabWidth, ok := d.Raw["tab_width"]
-			if ok && tabWidth == "unset" {
-				iniSec.NewKey(k, tabWidth)
+			if ok && tabWidth == UnsetValue {
+				v = tabWidth
 			} else {
-				iniSec.NewKey(k, strconv.Itoa(d.TabWidth))
+				v = strconv.Itoa(d.TabWidth)
 			}
-		} else if k == "indent_size" {
-			iniSec.NewKey(k, d.IndentSize)
-		} else {
-			iniSec.NewKey(k, v)
+		case "indent_size":
+			v = d.IndentSize
 		}
+
+		iniSec.NewKey(k, v) // nolint: errcheck
 	}
 
 	if _, ok := d.Raw["indent_size"]; !ok {
 		tabWidth, ok := d.Raw["tab_width"]
-		if ok && tabWidth == "unset" {
+		switch {
+		case ok && tabWidth == UnsetValue:
 			// do nothing
-		} else if d.TabWidth > 0 {
-			iniSec.NewKey("indent_size", strconv.Itoa(d.TabWidth))
-		} else if d.IndentStyle == IndentStyleTab && (d.version == nil || d.version.GTE(v0_9_0)) {
-			iniSec.NewKey("indent_size", IndentStyleTab)
+		case d.TabWidth > 0:
+			iniSec.NewKey("indent_size", strconv.Itoa(d.TabWidth)) // nolint: errcheck
+		case d.IndentStyle == IndentStyleTab && (d.version == nil || d.version.GTE(v0_9_0)):
+			iniSec.NewKey("indent_size", IndentStyleTab) // nolint: errcheck
 		}
 	}
 
 	if _, ok := d.Raw["tab_width"]; !ok {
-		if d.IndentSize == "unset" {
-			iniSec.NewKey("tab_width", d.IndentSize)
+		if d.IndentSize == UnsetValue {
+			iniSec.NewKey("tab_width", d.IndentSize) // nolint: errcheck
 		} else {
 			_, err := strconv.Atoi(d.IndentSize)
 			if err == nil {
-				iniSec.NewKey("tab_width", d.Raw["indent_size"])
+				iniSec.NewKey("tab_width", d.Raw["indent_size"]) // nolint: errcheck
 			}
 		}
 	}

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -2,14 +2,10 @@ package editorconfig
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 
-	"github.com/blang/semver"
 	"gopkg.in/ini.v1"
 )
 
@@ -49,156 +45,25 @@ const (
 	MaxValueLength    = 255
 )
 
-var (
-	v0_9_0 = semver.Version{
-		Major: 0,
-		Minor: 9,
-		Patch: 0,
-	}
-)
-
-// Config holds the configuration
-type Config struct {
-	Path    string
-	Name    string
-	Version string
-}
-
-// NewDefinition builds a definition from a given config
-func NewDefinition(config Config) (*Definition, error) {
-	if config.Name == "" {
-		config.Name = ConfigNameDefault
-	}
-
-	abs, err := filepath.Abs(config.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	config.Path = abs
-
-	return newDefinition(config)
-}
-
-// newDefinition recursively builds the definition
-func newDefinition(config Config) (*Definition, error) {
-	definition := &Definition{}
-	definition.Raw = make(map[string]string)
-
-	if config.Version != "" {
-		version, err := semver.New(config.Version)
-		if err != nil {
-			return nil, err
-		}
-		definition.version = version
-	}
-
-	dir := config.Path
-	for dir != filepath.Dir(dir) {
-		dir = filepath.Dir(dir)
-		ecFile := filepath.Join(dir, config.Name)
-		fp, err := os.Open(ecFile)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
-			}
-			continue
-		}
-		defer fp.Close()
-		ec, err := Parse(fp)
-		if err != nil {
-			return nil, err
-		}
-
-		relativeFilename := config.Path
-		if len(dir) < len(relativeFilename) {
-			relativeFilename = relativeFilename[len(dir):]
-		}
-
-		def, err := ec.GetDefinitionForFilename(relativeFilename)
-		if err != nil {
-			return nil, err
-		}
-
-		definition.merge(def)
-
-		if ec.Root {
-			break
-		}
-	}
-
-	return definition, nil
-
-}
-
-// Definition represents a definition inside the .editorconfig file.
-// E.g. a section of the file.
-// The definition is composed of the selector ("*", "*.go", "*.{js.css}", etc),
-// plus the properties of the selected files.
-type Definition struct {
-	Selector string `ini:"-" json:"-"`
-
-	Charset                string            `ini:"charset" json:"charset,omitempty"`
-	IndentStyle            string            `ini:"indent_style" json:"indent_style,omitempty"`
-	IndentSize             string            `ini:"indent_size" json:"indent_size,omitempty"`
-	TabWidth               int               `ini:"-" json:"-"`
-	EndOfLine              string            `ini:"end_of_line" json:"end_of_line,omitempty"`
-	TrimTrailingWhitespace *bool             `ini:"-" json:"-"`
-	InsertFinalNewline     *bool             `ini:"-" json:"-"`
-	Raw                    map[string]string `ini:"-" json:"-"`
-	version                *semver.Version
-}
-
 // Editorconfig represents a .editorconfig file.
+//
 // It is composed by a "root" property, plus the definitions defined in the
 // file.
 type Editorconfig struct {
 	Root        bool
 	Definitions []*Definition
-}
-
-// Parse parses from a reader.
-func Parse(r io.Reader) (*Editorconfig, error) {
-	iniFile, err := ini.Load(r)
-	if err != nil {
-		return nil, err
-	}
-
-	return newEditorconfig(iniFile)
-}
-
-// ParseBytes parses from a slice of bytes.
-//
-// Deprecated: use Parse instead.
-func ParseBytes(data []byte) (*Editorconfig, error) {
-	iniFile, err := ini.Load(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return newEditorconfig(iniFile)
-}
-
-// ParseFile parses from a file.
-//
-// Deprecated: use Parse instead.
-func ParseFile(path string) (*Editorconfig, error) {
-	iniFile, err := ini.Load(path)
-	if err != nil {
-		return nil, err
-	}
-
-	return newEditorconfig(iniFile)
+	config      *Config
 }
 
 // newEditorconfig builds the configuration from an INI file.
 func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
-	editorConfig := &Editorconfig{}
-
-	// Consider mixed-case values for true and false.
 	rootKey := iniFile.Section(ini.DefaultSection).Key("root")
 	rootKey.SetValue(strings.ToLower(rootKey.Value()))
-	editorConfig.Root = rootKey.MustBool(false)
+	isRoot := rootKey.MustBool(false)
+
+	editorConfig := &Editorconfig{
+		Root: isRoot,
+	}
 
 	for _, sectionStr := range iniFile.SectionStrings() {
 		if sectionStr == ini.DefaultSection || len(sectionStr) > MaxSectionLength {
@@ -207,13 +72,13 @@ func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 
 		iniSection := iniFile.Section(sectionStr)
 		definition := &Definition{}
-		err := iniSection.MapTo(&definition)
-		if err != nil {
+		raw := make(map[string]string)
+
+		if err := iniSection.MapTo(&definition); err != nil {
 			return nil, err
 		}
 
-		// Shallow copy all properties
-		raw := make(map[string]string)
+		// Shallow copy all the properties
 		for k, v := range iniSection.KeysHash() {
 			if len(k) > MaxPropertyLength || len(v) > MaxValueLength {
 				continue
@@ -223,178 +88,31 @@ func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
 		definition.Raw = raw
 
 		definition.Selector = sectionStr
+
 		if err := definition.normalize(); err != nil {
 			return nil, err
 		}
+
 		editorConfig.Definitions = append(editorConfig.Definitions, definition)
 	}
 
 	return editorConfig, nil
 }
 
-// normalize fixes some values to their lowercaes value
-func (d *Definition) normalize() error {
-	d.Charset = strings.ToLower(d.Charset)
-	d.EndOfLine = strings.ToLower(d.Raw["end_of_line"])
-	d.IndentStyle = strings.ToLower(d.Raw["indent_style"])
-
-	trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
-	if ok && trimTrailingWhitespace != UnsetValue {
-		trim, err := strconv.ParseBool(trimTrailingWhitespace)
-		if err != nil {
-			return fmt.Errorf("trim_trailing_whitespace=%s is not an acceptable value. %s", trimTrailingWhitespace, err)
-		}
-		d.TrimTrailingWhitespace = &trim
-	}
-
-	insertFinalNewline, ok := d.Raw["insert_final_newline"]
-	if ok && insertFinalNewline != UnsetValue {
-		insert, err := strconv.ParseBool(insertFinalNewline)
-		if err != nil {
-			return fmt.Errorf("insert_final_newline=%s is not an acceptable value. %s", insertFinalNewline, err)
-		}
-		d.InsertFinalNewline = &insert
-	}
-
-	// tab_width from Raw
-	tabWidth, ok := d.Raw["tab_width"]
-	if ok && tabWidth != UnsetValue {
-		num, err := strconv.Atoi(tabWidth)
-		if err != nil {
-			return fmt.Errorf("tab_width=%s is not an acceptable value. %s", tabWidth, err)
-		}
-		d.TabWidth = num
-	}
-
-	// tab_width defaults to indent_size:
-	// https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#tab_width
-	num, err := strconv.Atoi(d.IndentSize)
-	if err == nil && d.TabWidth <= 0 {
-		d.TabWidth = num
-	}
-
-	return nil
-}
-
-// merge the parent definition into the child definition
-func (d *Definition) merge(md *Definition) {
-	if len(d.Charset) == 0 {
-		d.Charset = md.Charset
-	}
-	if len(d.IndentStyle) == 0 {
-		d.IndentStyle = md.IndentStyle
-	}
-	if len(d.IndentSize) == 0 {
-		d.IndentSize = md.IndentSize
-	}
-	if d.TabWidth <= 0 {
-		d.TabWidth = md.TabWidth
-	}
-	if len(d.EndOfLine) == 0 {
-		d.EndOfLine = md.EndOfLine
-	}
-	if trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]; !ok || trimTrailingWhitespace != "unset" {
-		if d.TrimTrailingWhitespace == nil {
-			d.TrimTrailingWhitespace = md.TrimTrailingWhitespace
-		}
-	}
-	if insertFinalNewline, ok := d.Raw["insert_final_newline"]; !ok || insertFinalNewline != "unset" {
-		if d.InsertFinalNewline == nil {
-			d.InsertFinalNewline = md.InsertFinalNewline
-		}
-	}
-
-	for k, v := range md.Raw {
-		if _, ok := d.Raw[k]; !ok {
-			d.Raw[k] = v
-		}
-	}
-}
-
-func setValues(d *Definition, iniSection *ini.Section, key string, value string) {
-	switch key {
-	case "insert_final_newline":
-		if d.InsertFinalNewline != nil {
-			iniSection.NewKey(key, strconv.FormatBool(*d.InsertFinalNewline)) // nolint:errcheck
-		} else {
-			insertFinalNewline, ok := d.Raw["insert_final_newline"]
-			if ok {
-				iniSection.NewKey(key, strings.ToLower(insertFinalNewline)) // nolint: errcheck
-			}
-		}
-	case "trim_trailing_whitespace":
-		if d.TrimTrailingWhitespace != nil {
-			iniSection.NewKey(key, strconv.FormatBool(*d.TrimTrailingWhitespace)) // nolint:errcheck
-		} else {
-			trimTrailingWhitespace, ok := d.Raw["trim_trailing_whitespace"]
-			if ok {
-				iniSection.NewKey(key, strings.ToLower(trimTrailingWhitespace)) // nolint:errcheck
-			}
-		}
-	case "charset":
-		iniSection.NewKey(key, d.Charset) // nolint:errcheck
-	case "end_of_line":
-		iniSection.NewKey(key, d.EndOfLine) // nolint:errcheck
-	case "indent_style":
-		iniSection.NewKey(key, d.IndentStyle) // nolint:errcheck
-	case "tab_width":
-		tabWidth, ok := d.Raw["tab_width"]
-		if ok && tabWidth == UnsetValue {
-			iniSection.NewKey(key, tabWidth) // nolint:errcheck
-		} else {
-			iniSection.NewKey(key, strconv.Itoa(d.TabWidth)) // nolint:errcheck
-		}
-	case "indent_size":
-		iniSection.NewKey(key, d.IndentSize) // nolint:errcheck
-	default:
-		iniSection.NewKey(key, value) // nolint:errcheck
-	}
-}
-
-func setRawValues(d *Definition, iniSection *ini.Section) {
-	if _, ok := d.Raw["indent_size"]; !ok {
-		tabWidth, ok := d.Raw["tab_width"]
-		switch {
-		case ok && tabWidth == UnsetValue:
-			// do nothing
-		case d.TabWidth > 0:
-			iniSection.NewKey("indent_size", strconv.Itoa(d.TabWidth)) // nolint:errcheck
-		case d.IndentStyle == IndentStyleTab && (d.version == nil || d.version.GTE(v0_9_0)):
-			iniSection.NewKey("indent_size", IndentStyleTab) // nolint:errcheck
-		}
-	}
-
-	if _, ok := d.Raw["tab_width"]; !ok {
-		if d.IndentSize == UnsetValue {
-			iniSection.NewKey("tab_width", d.IndentSize) // nolint:errcheck
-		} else {
-			_, err := strconv.Atoi(d.IndentSize)
-			if err == nil {
-				iniSection.NewKey("tab_width", d.Raw["indent_size"]) // nolint:errcheck
-			}
-		}
-	}
-}
-
-// InsertToIniFile ... TODO
-func (d *Definition) InsertToIniFile(iniFile *ini.File) {
-	iniSec := iniFile.Section(d.Selector)
-	for k, v := range d.Raw {
-		setValues(d, iniSec, k, v)
-	}
-
-	setRawValues(d, iniSec)
-}
-
 // GetDefinitionForFilename returns a definition for the given filename.
+//
 // The result is a merge of the selectors that matched the file.
 // The last section has preference over the priors.
 func (e *Editorconfig) GetDefinitionForFilename(name string) (*Definition, error) {
-	def := &Definition{}
-	def.Raw = make(map[string]string)
+	def := &Definition{
+		Raw: make(map[string]string),
+	}
+
+	// The last section has preference over the priors.
 	for i := len(e.Definitions) - 1; i >= 0; i-- {
 		actualDef := e.Definitions[i]
 		selector := actualDef.Selector
+
 		if !strings.HasPrefix(selector, "/") {
 			if strings.ContainsRune(selector, '/') {
 				selector = "/" + selector
@@ -402,10 +120,13 @@ func (e *Editorconfig) GetDefinitionForFilename(name string) (*Definition, error
 				selector = "/**/" + selector
 			}
 		}
+
 		if !strings.HasPrefix(name, "/") {
 			name = "/" + name
 		}
-		ok, err := FnmatchCase(selector, name)
+
+		ok, err := e.FnmatchCase(selector, name)
+
 		if err != nil {
 			return nil, err
 		}
@@ -413,14 +134,17 @@ func (e *Editorconfig) GetDefinitionForFilename(name string) (*Definition, error
 			def.merge(actualDef)
 		}
 	}
+
 	return def, nil
 }
 
-func boolToString(b bool) string {
-	if b {
-		return "true"
+// FnmatchCase calls the matcher from the config's parser or the vanilla's.
+func (e *Editorconfig) FnmatchCase(selector string, filename string) (bool, error) {
+	if e.config != nil && e.config.Parser != nil {
+		return e.config.Parser.FnmatchCase(selector, filename)
 	}
-	return "false"
+
+	return FnmatchCase(selector, filename)
 }
 
 // Serialize converts the Editorconfig to a slice of bytes, containing the
@@ -459,15 +183,55 @@ func (e *Editorconfig) Save(filename string) error {
 	return e.Write(f)
 }
 
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// Parse parses from a reader.
+func Parse(r io.Reader) (*Editorconfig, error) {
+	iniFile, err := ini.Load(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEditorconfig(iniFile)
+}
+
+// ParseBytes parses from a slice of bytes.
+//
+// Deprecated: use Parse instead.
+func ParseBytes(data []byte) (*Editorconfig, error) {
+	iniFile, err := ini.Load(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEditorconfig(iniFile)
+}
+
+// ParseFile parses from a file.
+//
+// Deprecated: use Parse instead.
+func ParseFile(path string) (*Editorconfig, error) {
+	iniFile, err := ini.Load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return newEditorconfig(iniFile)
+}
+
 // GetDefinitionForFilename given a filename, searches
 // for .editorconfig files, starting from the file folder,
 // walking through the previous folders, until it reaches a
 // folder with `root = true`, and returns the right editorconfig
 // definition for the given file.
 func GetDefinitionForFilename(filename string) (*Definition, error) {
-	return NewDefinition(Config{
-		Path: filename,
-	})
+	config := new(Config)
+	return config.Load(filename)
 }
 
 // GetDefinitionForFilenameWithConfigname given a filename and a configname,
@@ -476,8 +240,9 @@ func GetDefinitionForFilename(filename string) (*Definition, error) {
 // folder with `root = true`, and returns the right editorconfig
 // definition for the given file.
 func GetDefinitionForFilenameWithConfigname(filename string, configname string) (*Definition, error) {
-	return NewDefinition(Config{
-		Path: filename,
+	config := &Config{
 		Name: configname,
-	})
+	}
+
+	return config.Load(filename)
 }

--- a/editorconfig.go
+++ b/editorconfig.go
@@ -57,13 +57,12 @@ type Editorconfig struct {
 
 // newEditorconfig builds the configuration from an INI file.
 func newEditorconfig(iniFile *ini.File) (*Editorconfig, error) {
+	editorConfig := &Editorconfig{}
+
+	// Consider mixed-case values for true and false.
 	rootKey := iniFile.Section(ini.DefaultSection).Key("root")
 	rootKey.SetValue(strings.ToLower(rootKey.Value()))
-	isRoot := rootKey.MustBool(false)
-
-	editorConfig := &Editorconfig{
-		Root: isRoot,
-	}
+	editorConfig.Root = rootKey.MustBool(false)
 
 	for _, sectionStr := range iniFile.SectionStrings() {
 		if sectionStr == ini.DefaultSection || len(sectionStr) > MaxSectionLength {

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,12 @@
+package editorconfig
+
+import (
+	"gopkg.in/ini.v1"
+)
+
+// Parser interface is responsible for the parsing of the ini file and the
+// globbing patterns.
+type Parser interface {
+	ParseIni(string) (*ini.File, error)
+	FnmatchCase(string, string) (bool, error)
+}

--- a/simple_parser.go
+++ b/simple_parser.go
@@ -1,0 +1,26 @@
+package editorconfig
+
+import (
+	"os"
+
+	"gopkg.in/ini.v1"
+)
+
+type SimpleParser struct{}
+
+// ParseIni calls go-ini's Load on the file.
+func (parser *SimpleParser) ParseIni(filename string) (*ini.File, error) {
+	fp, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	defer fp.Close()
+
+	return ini.Load(fp)
+}
+
+// FnmatchCase calls the module's FnmatchCase.
+func (parser *SimpleParser) FnmatchCase(selector string, filename string) (bool, error) {
+	return FnmatchCase(selector, filename)
+}


### PR DESCRIPTION
This addresses the closed issue #30.

Now on https://github.com/dotnet/roslyn

```console
$ time editorconfig $(git ls-files)

real    0m8.061s
user    0m8.973s
sys     0m0.470s
```

This branch

```console
$ time editorconfig $(git ls-files)

real    0m3.426s
user    0m3.777s
sys     0m0.224s
```

It didn't change any of the API and should be backward compatible.

Usage in the wild, https://gitlab.com/greut/eclint/merge_requests/38