### PR TITLE
prepare v2.4.3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,19 +27,18 @@ archives:
 
 dockers:
 - image_templates:
-  - docker.pkg.github.com/editorconfig/editorconfig-core-go/editorconfig:latest
-  - docker.pkg.github.com/editorconfig/editorconfig-core-go/editorconfig:{{ .Tag }}
-  - docker.pkg.github.com/editorconfig/editorconfig-core-go/editorconfig:v{{ .Major }}
-  - docker.pkg.github.com/editorconfig/editorconfig-core-go/editorconfig:v{{ .Major }}.{{ .Minor }}
+  - ghcr.io/editorconfig/editorconfig-core-go/editorconfig:latest
+  - ghcr.io/editorconfig/editorconfig-core-go/editorconfig:{{ .Tag }}
+  - ghcr.io/editorconfig/editorconfig-core-go/editorconfig:v{{ .Major }}
+  - ghcr.io/editorconfig/editorconfig-core-go/editorconfig:v{{ .Major }}.{{ .Minor }}
   goos: linux
   goarch: amd64
   ids:
   - editorconfig
   build_flag_templates:
   - "--pull"
-  - "--label=org.label-schema.schema-version=1.0"
-  - "--label=org.label-schema.version={{ .Version }}"
-  - "--label=org.label-schema.name={{ .ProjectName }}"
+  - "--label=org.opencontainers.image.version={{ .Version }}"
+  - "--label=org.opencontainers.image.title={{ .ProjectName }}"
 
 nfpms:
 - vendor: EditorConfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## v2.4.3 - 2021-09-21
+
+- Upgrade go-cmp v0.5.6
+  ([#110](https://github.com/editorconfig/editorconfig-core-go/pull/110));
+- Upgrade go-ini v1.63.2;
+- Upgrade x/mod v0.5.0
+  ([#111](https://github.com/editorconfig/editorconfig-core-go/pull/111));
+- Fix problems spotted by golangci-lint
+  ([#115](https://github.com/editorconfig/editorconfig-core-go/pull/115));
+
 ## v2.4.2 - 2021-03-21
 
 - Upgrade google/go-cmp v0.5.5


### PR DESCRIPTION
- Upgrade go-cmp v0.5.6
  ([#110](https://github.com/editorconfig/editorconfig-core-go/pull/110));
- Upgrade go-ini v1.63.2;
- Upgrade x/mod v0.5.0
  ([#111](https://github.com/editorconfig/editorconfig-core-go/pull/111));
- Fix problems spotted by golangci-lint
  ([#115](https://github.com/editorconfig/editorconfig-core-go/pull/115));