### PR TITLE
feat: bump golangci-lint from 1.42 to 1.43

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.43

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - maligned
     - scopelint
     - tagliatelle
+    - varnamelen
   presets:
     - bugs
     - complexity

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/editorconfig/editorconfig-core-go/v2
 
-go 1.13
+go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
Go 1.15 is the last supported one, so bumping make sense as well.