### PR TITLE
prepare v2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## v2.4.4 - 2022-03-16
+## v2.4.4 - 2022-03-17
 
 - Upgrade gopkg.in/ini.v1 from 1.53 to 1.66.4;
 - Upgrade github.com/google/go-cmp from 0.5.6 to 0.5.7;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v2.4.4 - 2022-03-16
+
+- Upgrade gopkg.in/ini.v1 from 1.53 to 1.66.4;
+- Upgrade github.com/google/go-cmp from 0.5.6 to 0.5.7;
+- Upgrade golang.org/x/mod from 0.5.0 to 0.5.1.
+
 ## v2.4.3 - 2021-09-21
 
 - Upgrade go-cmp v0.5.6


### PR DESCRIPTION
241a82b feat: bump golangci-lint from 1.43 to 1.44
9f6d1eb build(deps): bump gopkg.in/ini.v1 from 1.66.3 to 1.66.4 (#124)
64542a4 build(deps): bump gopkg.in/ini.v1 from 1.66.2 to 1.66.3 (#123)
4564d8d build(deps): bump github.com/google/go-cmp from 0.5.6 to 0.5.7 (#122)
1dba889 build(deps): bump gopkg.in/ini.v1 from 1.65.0 to 1.66.2 (#121)
9925b14 build(deps): bump gopkg.in/ini.v1 from 1.64.0 to 1.65.0 (#120)
6c6a3c5 build(deps): bump gopkg.in/ini.v1 from 1.63.2 to 1.64.0 (#119)
a4dd340 feat: bump golangci-lint from 1.42 to 1.43 (#118)
ef4b4a3 build(deps): bump golang.org/x/mod from 0.5.0 to 0.5.1 (#117)