### PR TITLE
prepare v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## v2.5.0 - 2022-10-01
+
+- Feature add a graceful parser that reports errors in the .editorconfig file as warnings
+- Bump Go version to 1.18 in the go.mod
+- Bump go.pkg.in/ini.v1 to 1.67.0
+- Bump google/go-cmp to 0.5.9
+
 ## v2.4.5 - 2022-06-18
 
 - Bump Go version to 1.17 in the go.mod

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/hashicorp/go-multierror v1.1.1
 	golang.org/x/mod v0.5.1
 	gopkg.in/ini.v1 v1.67.0
 )
 
 require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 )


### PR DESCRIPTION
2552daa feat: graceful parser (#144)
8f29b26 build(deps): bump github.com/google/go-cmp from 0.5.8 to 0.5.9 (#143)
43b5f7f fix: golangci-lint warnings (#142)
628ea1d build(deps): bump gopkg.in/ini.v1 from 1.66.6 to 1.67.0 (#141)
560dd96 chore: tests using Go 1.19 (#139)
bdd12ab feat: enable semgrep checks (#138)
5392fc9 fix: badge pointing to pkg.go.dev (#137)