### PR TITLE
chore: bump core-test to latest commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(editorconfig-core-go)
 cmake_minimum_required(VERSION 3.13)
+project(editorconfig-core-go)
 enable_testing()
 set(EDITORCONFIG_CMD ${CMAKE_CURRENT_LIST_DIR}/editorconfig)
 add_subdirectory(core-test)


### PR DESCRIPTION
Those tests are failing locally, maybe things are better here.