### PR TITLE
Enable syntax highlight for README blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if err != nil {
 
 ### Graceful parsing from a file
 
-```
+```go
 fp, err := os.Open("path/to/.editorconfig")
 if err != nil {
 	log.Fatal(err)
@@ -144,7 +144,7 @@ go test -v ./...
 
 To run the [integration tests](https://github.com/editorconfig/editorconfig-core-test):
 
-```
+```bash
 make test-core
 ```
 


### PR DESCRIPTION
Some code blocks in README were not sytnax-highlighted, this fixes it.