### PR TITLE
prepare v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## v2.5.2 - 2023-04-19
+
+- Bump golang.org/x/mod from 0.5.1 to 0.10.0
+
 ## v2.5.1 - 2022-10-02
 
 - Fix typo in new method


### PR DESCRIPTION
## Changelog

1e4e424 build(deps): bump golang.org/x/mod from 0.9.0 to 0.10.0 (#158)
0d9cdb0 Enable syntax highlight for README blocks (#157)
c9a07ab fix(ci): bump golangci-lint from 1.49 to 1.52 (#159)
538b503 fix: skip breaking tests (#160)
6406360 chore: bump core-test to latest commit (#155)
ff9d931 build(deps): bump actions/setup-go from 3 to 4 (#154)
590fec6 build(deps): bump golang.org/x/mod from 0.8.0 to 0.9.0 (#153)
75e8a05 build(deps): bump golang.org/x/mod from 0.7.0 to 0.8.0 (#152)
a9628e7 build(deps): bump golangci/golangci-lint-action from 3.3.1 to 3.4.0 (#151)
400423e build(deps): bump golang.org/x/mod from 0.6.0 to 0.7.0 (#149)
819d576 build(deps): bump golangci/golangci-lint-action from 3.3.0 to 3.3.1 (#150)
125b3f3 build(deps): bump golangci/golangci-lint-action from 3.2.0 to 3.3.0 (#148)
47eaadd build(deps): bump golang.org/x/mod from 0.5.1 to 0.6.0 (#147)