### PR TITLE
prepare v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## v2.6.0 - 2023-09-27
+
+- Fix path matching on Windows. The spec says that:
+
+  > Backslashes (`\\`) are not allowed as path separators (even on Windows).
+- Replace go-multierror with Go 1.20 errors.Join
+
 ## v2.5.2 - 2023-04-19
 
 - Bump golang.org/x/mod from 0.5.1 to 0.10.0


### PR DESCRIPTION
## Changelog

7354273 fix: path matches on Windows (#170)
de7896a build(deps): bump actions/checkout from 3 to 4 (#169)
0bb51f1 build(deps): bump golangci/golangci-lint-action from 3.6.0 to 3.7.0 (#167)
73c37c4 feat: replace go-multierror with Go 1.20 native joins (#156)
83a3feb chore(ci): bump golangci-lint to 1.53 (#166)
d17d599 build(deps): bump golang.org/x/mod from 0.11.0 to 0.12.0 (#165)
9b237be build(deps): bump golang.org/x/mod from 0.10.0 to 0.11.0 (#163)
c6257d5 build(deps): bump golangci/golangci-lint-action from 3.5.0 to 3.6.0 (#164)
b864fff build(deps): bump golangci/golangci-lint-action from 3.4.0 to 3.5.0 (#162)