### PR TITLE
prepare v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v2.6.1 - 2024-01-29
+
+- Fix utf-8-bom contains a dash
+- Bump google/go-cmp to 0.6.0
+- Bump x/mod to 0.14.0
+
 ## v2.6.0 - 2023-09-27
 
 - Fix path matching on Windows. The spec says that:


### PR DESCRIPTION
## Changelog

547c5f1 fix: utf-8-bom with dash (#177)
8fd941d build(deps): bump actions/setup-go from 4 to 5 (#175)
b573fe4 build(deps): bump golang.org/x/mod from 0.13.0 to 0.14.0 (#174)
2b5ef76 build(deps): bump github.com/google/go-cmp from 0.5.9 to 0.6.0 (#173)
03a0664 build(deps): bump golang.org/x/mod from 0.12.0 to 0.13.0 (#172)