### PR TITLE
prepare v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v2.6.2 - 2024-04-02
+
+- Fix paths on Windows
+- Bump golangci-lint to 1.56
+- Bump x/mod to 0.16.0
+
 ## v2.6.1 - 2024-01-29
 
 - Fix utf-8-bom contains a dash


### PR DESCRIPTION
a5a5d12 fix: Windows path overrides are broken (#184)
a73573b chore: bump golanci-lint from 1.54 to 1.56 (#182)
308412c build(deps): bump golang.org/x/mod from 0.15.0 to 0.16.0 (#183)
e00541f build(deps): bump golangci/golangci-lint-action from 3.7.0 to 4.0.0 (#180)
8774f2b build(deps): bump golang.org/x/mod from 0.14.0 to 0.15.0 (#179)