### PR TITLE
Prepare v2.6.3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: editorconfig-core-go
 
 before:
@@ -21,7 +23,8 @@ archives:
   - editorconfig
   format_overrides:
   - goos: windows
-    format: zip
+    formats:
+      - zip
   files:
   - none*
 
@@ -57,7 +60,7 @@ signs:
 - artifacts: checksum
 
 snapshot:
-  name_template: "{{ .Tag }}-development"
+  version_template: "{{ .Tag }}-development"
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v2.6.3 - 2025-03-12
+
+- Targets Go 1.22
+- Bump x/mod to 0.23
+- Bump google/go-cmp to 0.7.0
+
 ## v2.6.2 - 2024-04-02
 
 - Fix paths on Windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
 COPY editorconfig /usr/local/bin/
 


### PR DESCRIPTION
Before bumping the minimum Go version.