### PR TITLE
Update .editorconfig to include defaults for go.work and go.work.sum as a reference for Go projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+[{Makefile,go.mod,go.work,go.work.sum,go.sum,*.go,.gitmodules}]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
Since this file is also used as the reference for Go projects, I thought I would add these missing files here