### PR TITLE
prepare v2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change log
 
+## v2.6.4 - 2025-12-16
+
+- Target Go 1.24
+- Bump x/mod to 0.31
+- Typos
+
 ## v2.6.3 - 2025-03-12
 
-- Targets Go 1.22
+- Target Go 1.22
 - Bump x/mod to 0.23
 - Bump google/go-cmp to 0.7.0
 


### PR DESCRIPTION
## Changelog

d29864e build(deps): bump golang.org/x/mod from 0.30.0 to 0.31.0 (#225)
3167783 build(deps): bump golangci/golangci-lint-action from 9.1.0 to 9.2.0 (#224)
f62810d build(deps): bump actions/checkout from 5 to 6 (#223)
b237e23 build(deps): bump golangci/golangci-lint-action from 9.0.0 to 9.1.0 (#222)
4f323dd build(deps): bump golang.org/x/mod from 0.29.0 to 0.30.0 (#221)
bae4034 build(deps): bump golangci/golangci-lint-action from 8.0.0 to 9.0.0 (#220)
620423f build(deps): bump golang.org/x/mod from 0.28.0 to 0.29.0 (#219)
610abda build(deps): bump golang.org/x/mod from 0.27.0 to 0.28.0 (#216)
cf733df build(deps): bump actions/setup-go from 5 to 6 (#217)
6102434 fix: address golangci-lint issues (#218)
15aac10 build(deps): bump actions/checkout from 4 to 5 (#215)
b56a8fb build(deps): bump golang.org/x/mod from 0.26.0 to 0.27.0 (#214)
fb7e18b build(deps): bump golang.org/x/mod from 0.25.0 to 0.26.0 (#213)
d87d326 build(deps): bump golang.org/x/mod from 0.24.0 to 0.25.0 (#212)
6826a3b Update .editorconfig to include defaults for go.work and go.work.sum as a reference for Go projects (#210)
9f1784a build(deps): bump golangci/golangci-lint-action from 6.5.2 to 8.0.0 (#211)
3ed1d03 spelling: whether (#209)
e88dcd8 spelling: https (#208)
7404f9a build(deps): bump golangci/golangci-lint-action from 6.5.1 to 6.5.2 (#206)
fb77f1a build(deps): bump golangci/golangci-lint-action from 6.5.0 to 6.5.1 (#205)
16fe22a build(deps): bump golang.org/x/mod from 0.23.0 to 0.24.0 (#202)